### PR TITLE
feat: add default type for Input

### DIFF
--- a/.changeset/purple-cobras-bathe.md
+++ b/.changeset/purple-cobras-bathe.md
@@ -1,0 +1,5 @@
+---
+"@wip/input": minor
+---
+
+Use "text" as the default input type

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -6,9 +6,10 @@ interface Props
   appearance?: "error";
 }
 
-export const Input = ({ appearance, ...restProps }: Props) => (
+export const Input = ({ appearance, type = "text", ...restProps }: Props) => (
   <input
     className={clsx("input", { ["input--error"]: appearance === "error" })}
+    type={type}
     {...restProps}
   />
 );


### PR DESCRIPTION
Make "text" the default type for input fields.