### PR TITLE
feat: add default input type

### DIFF
--- a/.changeset/cold-rice-pay.md
+++ b/.changeset/cold-rice-pay.md
@@ -1,0 +1,5 @@
+---
+"@wip/input": minor
+---
+
+Set a default input type of "text" on the Input component

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -6,9 +6,10 @@ interface Props
   appearance?: "error";
 }
 
-export const Input = ({ appearance, ...restProps }: Props) => (
+export const Input = ({ appearance, type = "text", ...restProps }: Props) => (
   <input
     className={clsx("input", { ["input--error"]: appearance === "error" })}
+    type={type}
     {...restProps}
   />
 );


### PR DESCRIPTION
Set a default input type of "text" on the Input component