### PR TITLE
feat: add a default type for Input

### DIFF
--- a/.changeset/cyan-bags-double.md
+++ b/.changeset/cyan-bags-double.md
@@ -1,0 +1,5 @@
+---
+"@matijs/input": minor
+---
+
+Add default type for Input

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -6,9 +6,10 @@ interface Props
   appearance?: "error";
 }
 
-export const Input = ({ appearance, ...restProps }: Props) => (
+export const Input = ({ appearance, type = "text", ...restProps }: Props) => (
   <input
     className={clsx("input", { ["input--error"]: appearance === "error" })}
+    type={type}
     {...restProps}
   />
 );


### PR DESCRIPTION
Make the Input component default to a `type="text"`