### PR TITLE
feat: add default button type

### DIFF
--- a/.changeset/khaki-kings-repeat.md
+++ b/.changeset/khaki-kings-repeat.md
@@ -1,0 +1,5 @@
+---
+"@matijs/button": minor
+---
+
+Add default button type

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -6,12 +6,18 @@ interface Props
   appearance: "primary" | "secondary";
 }
 
-export const Button = ({ appearance, children, ...restProps }: Props) => (
+export const Button = ({
+  appearance,
+  children,
+  type = "submit",
+  ...restProps
+}: Props) => (
   <button
     className={clsx("button", {
       ["button--primary"]: appearance === "primary",
       ["button--secondary"]: appearance === "secondary",
     })}
+    type={type}
     {...restProps}
   >
     {children}


### PR DESCRIPTION
Make button explicitly default to `type="button"` instead of doing it silently