### PR TITLE
feat: add default button appearance

### DIFF
--- a/.changeset/neat-dolphins-hammer.md
+++ b/.changeset/neat-dolphins-hammer.md
@@ -1,0 +1,5 @@
+---
+"@matijs/button": patch
+---
+
+Make "secondary" the default button appearance

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -7,7 +7,7 @@ interface Props
 }
 
 export const Button = ({
-  appearance,
+  appearance = "secondary",
   children,
   type = "submit",
   ...restProps


### PR DESCRIPTION
Make "secondary" the default button appearance as secondary buttons can appear everywhere whereas there can only be one "primary" button in a given context.