### PR TITLE
fix: rename textarea package

### DIFF
--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wip/textarea",
+  "name": "@matijs/textarea",
   "version": "0.1.0",
   "main": "./dist/index.js",
   "license": "EUPL-1.2",


### PR DESCRIPTION
Packages need to be prefixed with use name