### PR TITLE
feat: make id mandatory on textarea

### DIFF
--- a/.changeset/many-avocados-brush.md
+++ b/.changeset/many-avocados-brush.md
@@ -1,0 +1,6 @@
+---
+"@matijs/textarea": major
+---
+
+Make the `id` prop mandatory. This makes sure that the user has to associate a
+`<label>` with the `<textarea>`.

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -6,11 +6,13 @@ interface Props
     TextareaHTMLAttributes<HTMLTextAreaElement>,
     "className" | "style"
   > {
+  id: "string";
   appearance?: "error";
 }
 
-export const Button = ({ children, appearance, ...restProps }: Props) => (
+export const Button = ({ id, children, appearance, ...restProps }: Props) => (
   <textarea
+    id={id}
     className={clsx("textarea", {
       ["textarea--error"]: appearance === "error",
     })}


### PR DESCRIPTION
To make sure that the user associates a `<label>` with the `<textarea>`, make the id attribute mandatory.