### PR TITLE
Feat/button

### DIFF
--- a/.changeset/lemon-news-wonder.md
+++ b/.changeset/lemon-news-wonder.md
@@ -1,0 +1,6 @@
+---
+"@matijs/input": major
+---
+
+[Breaking]: The `id` prop is now mandatory to ensure developers associate the
+`input` field with a `label`.

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -4,10 +4,17 @@ import { clsx } from "clsx";
 interface Props
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "style"> {
   appearance?: "error";
+  id: "string";
 }
 
-export const Input = ({ appearance, type = "text", ...restProps }: Props) => (
+export const Input = ({
+  appearance,
+  id,
+  type = "text",
+  ...restProps
+}: Props) => (
   <input
+    id={id}
     className={clsx("input", { ["input--error"]: appearance === "error" })}
     type={type}
     {...restProps}


### PR DESCRIPTION
Make sure developers associate a `label` with the `input` by making the `id` prop mandatory. This is a breaking change.